### PR TITLE
Add representedObject to token before calling addToken and created a removeAllTokens method.

### DIFF
--- a/TITokenField.h
+++ b/TITokenField.h
@@ -126,6 +126,7 @@ typedef enum {
 - (void)addToken:(TIToken *)title;
 - (TIToken *)addTokenWithTitle:(NSString *)title;
 - (void)removeToken:(TIToken *)token;
+- (void)removeAllTokens;
 
 - (void)selectToken:(TIToken *)token;
 - (void)deselectSelectedToken;

--- a/TITokenField.m
+++ b/TITokenField.m
@@ -594,6 +594,15 @@ NSString * const kTextHidden = @"\u200D"; // Zero-Width Joiner
 	}
 }
 
+- (void)removeAllTokens
+{
+    for(int i = [tokens count]-1; i >= 0; i--)
+    {
+        TIToken * t = [tokens objectAtIndex:i];
+        [self removeToken:t];
+    }
+}
+
 - (void)selectToken:(TIToken *)token {
 	
 	[self deselectSelectedToken];


### PR DESCRIPTION
Changed TITokenFieldView didSelectRowAtIndexPath so that the represented object is added before addToken is called. This allows delegates implementing willAddToken to have logic based on the represented object.

Also added a convenience method removeAllTokens to TITokenField. It simply loops through the tokens in reverse order and calls removeToken: for each one. 
