### PR TITLE
Fix for removing all tokens when not in editing mode.

### DIFF
--- a/TITokenField.m
+++ b/TITokenField.m
@@ -601,6 +601,8 @@ NSString * const kTextHidden = @"\u200D"; // Zero-Width Joiner
         TIToken * t = [tokens objectAtIndex:i];
         [self removeToken:t];
     }
+
+    [self setText:@""];
 }
 
 - (void)selectToken:(TIToken *)token {


### PR DESCRIPTION
If you call removeAllTokens when you are not in editing mode on the token field, then the tokens will be removed but the description text (eg "3 recipients") will remain. This commit sets the text to @"" after removing all the tokens. 
