### PR TITLE
FIX: delegate methods should only be called once

### DIFF
--- a/TITokenField.m
+++ b/TITokenField.m
@@ -582,10 +582,12 @@ NSString * const kTextHidden = @"\u200D"; // Zero-Width Joiner
 		[token addTarget:self action:@selector(tokenTouchUpInside:) forControlEvents:UIControlEventTouchUpInside];
 		[self addSubview:token];
 		
-		if (![tokens containsObject:token]) [tokens addObject:token];
+		if (![tokens containsObject:token]) {
+			[tokens addObject:token];
 		
-		if ([delegate respondsToSelector:@selector(tokenField:didAddToken:)]){
-			[delegate tokenField:self didAddToken:token];
+			if ([delegate respondsToSelector:@selector(tokenField:didAddToken:)]){
+				[delegate tokenField:self didAddToken:token];
+			}
 		}
 		
 		[self setResultsModeEnabled:NO];


### PR DESCRIPTION
When entering edit mode the [didAddToken] delegate method is called again for every token.
Delegate should only be called at creation.

The condition was there, shoulda just wrapped a couple more lines

Thanks for this by the way!
