### PR TITLE
[TITokenField] Fixed issue where addToken: does not get rid of placeholder text.

### DIFF
--- a/TITokenField.m
+++ b/TITokenField.m
@@ -551,10 +551,10 @@ NSString * const kTextHidden = @"\u200D"; // Zero-Width Joiner
 - (void)didChangeText {
 	if (self.text.length == 0) {
         [self setText:kTextEmpty];
-        [ _placeHolderLabel setHidden:NO];
+        [_placeHolderLabel setHidden:NO];
     }
     else{
-        [ _placeHolderLabel setHidden:YES];
+        [_placeHolderLabel setHidden:YES];
     }
 }
 
@@ -610,6 +610,8 @@ NSString * const kTextHidden = @"\u200D"; // Zero-Width Joiner
 			if ([delegate respondsToSelector:@selector(tokenField:didAddToken:)]){
 				[delegate tokenField:self didAddToken:token];
 			}
+            
+            [_placeHolderLabel setHidden:YES];
 		}
 		
 		[self setResultsModeEnabled:NO];


### PR DESCRIPTION
Using addToken: directly without typing any text now gets rid of placeholder in TITokenField.

Fixes this:
![screen shot 2013-07-12 at 4 54 15 pm](https://f.cloud.github.com/assets/4573957/791725/668ba9a0-eb4e-11e2-8048-00d1c222c3f1.png)
