### PR TITLE
Override sizeThatFits instead of sizeToFit

### DIFF
--- a/TITokenField.m
+++ b/TITokenField.m
@@ -1051,6 +1051,7 @@ CGPathRef CGPathCreateDisclosureIndicatorPath(CGPoint arrowPointFront, CGFloat h
 	if (newTitle){
 		_title = [newTitle copy];
 		[self sizeToFit];
+        [self setNeedsDisplay];
 	}
 }
 
@@ -1061,6 +1062,7 @@ CGPathRef CGPathCreateDisclosureIndicatorPath(CGPoint arrowPointFront, CGFloat h
 	if (_font != newFont){
 		_font = newFont;
 		[self sizeToFit];
+        [self setNeedsDisplay];
 	}
 }
 
@@ -1079,6 +1081,7 @@ CGPathRef CGPathCreateDisclosureIndicatorPath(CGPoint arrowPointFront, CGFloat h
 	if (_accessoryType != type){
 		_accessoryType = type;
 		[self sizeToFit];
+        [self setNeedsDisplay];
 	}
 }
 
@@ -1087,6 +1090,7 @@ CGPathRef CGPathCreateDisclosureIndicatorPath(CGPoint arrowPointFront, CGFloat h
 	if (_maxWidth != width){
 		_maxWidth = width;
 		[self sizeToFit];
+        [self setNeedsDisplay];
 	}
 }
 
@@ -1105,7 +1109,7 @@ CGPathRef CGPathCreateDisclosureIndicatorPath(CGPoint arrowPointFront, CGFloat h
 }
 
 #pragma mark Layout
-- (void)sizeToFit {
+- (CGSize)sizeThatFits:(CGSize)size {
 	
 	CGFloat accessoryWidth = 0;
 	
@@ -1117,8 +1121,7 @@ CGPathRef CGPathCreateDisclosureIndicatorPath(CGPoint arrowPointFront, CGFloat h
 	CGSize titleSize = [_title sizeWithFont:_font forWidth:(_maxWidth - hTextPadding - accessoryWidth) lineBreakMode:kLineBreakMode];
 	CGFloat height = floorf(titleSize.height + vTextPadding);
 	
-	[self setFrame:((CGRect){self.frame.origin, {MAX(floorf(titleSize.width + hTextPadding + accessoryWidth), height - 3), height}})];
-	[self setNeedsDisplay];
+    return (CGSize){MAX(floorf(titleSize.width + hTextPadding + accessoryWidth), height - 3), height};
 }
 
 #pragma mark Drawing


### PR DESCRIPTION
Hi, I found the following code

``` obj-c
- (void)sizeToFit {

    CGFloat accessoryWidth = 0;

    if (_accessoryType == TITokenAccessoryTypeDisclosureIndicator){
        CGPathRelease(CGPathCreateDisclosureIndicatorPath(CGPointZero, _font.pointSize, kDisclosureThickness, &accessoryWidth));
        accessoryWidth += floorf(hTextPadding / 2);
    }

    CGSize titleSize = [_title sizeWithFont:_font forWidth:(_maxWidth - hTextPadding - accessoryWidth) lineBreakMode:kLineBreakMode];
    CGFloat height = floorf(titleSize.height + vTextPadding);

    [self setFrame:((CGRect){self.frame.origin, {MAX(floorf(titleSize.width + hTextPadding + accessoryWidth), height - 3), height}})];
    [self setNeedsDisplay];
}
```

According to Apple's doc

> Resizes and moves the receiver view so it just encloses its subviews.
> Call this method when you want to resize the current view so that it uses the most appropriate amount of space. Specific UIKit views resize themselves according to their own internal needs. In some cases, if a view does not have a superview, it may size itself to the screen bounds. Thus, if you want a given view to size itself to its parent view, you should add it to the parent view before calling this method.
> 
> You **should not override** this method. If you want to change the default sizing information for your view, override the sizeThatFits: instead. That method performs any needed calculations and returns them to this method, which then makes the change.
