### PR TITLE
Fix layoutSubviews issue according to Apple'd API doc

### DIFF
--- a/TITokenField.m
+++ b/TITokenField.m
@@ -138,12 +138,12 @@
 	}
 	
 	[self updateContentSize];
-	[self layoutSubviews];
+	[self setNeedsLayout];
 }
 
 - (void)setContentOffset:(CGPoint)offset {
 	[super setContentOffset:offset];
-	[self layoutSubviews];
+	[self setNeedsLayout];
 }
 
 - (NSArray *)tokenTitles {


### PR DESCRIPTION
Just little fix.

According to Apple's API doc

> You **should not call this method directly**. If you want to force a layout update, call the `setNeedsLayout` method instead to do so prior to the next drawing update. If you want to update the layout of your views immediately, call the layoutIfNeeded method.
