### PR TITLE
Adding search in background thread

### DIFF
--- a/TITokenField.h
+++ b/TITokenField.h
@@ -59,6 +59,7 @@
 @property (nonatomic, assign) BOOL searchSubtitles;
 @property (nonatomic, assign) BOOL forcePickSearchResult;
 @property (nonatomic, assign) BOOL shouldSortResults;
+@property (nonatomic, assign) BOOL shouldSearchInBackground;
 @property (nonatomic, readonly) TITokenField * tokenField;
 @property (nonatomic, readonly) UIView * separator;
 @property (nonatomic, readonly) UITableView * resultsTable;

--- a/TITokenField.m
+++ b/TITokenField.m
@@ -36,6 +36,7 @@
 @synthesize searchSubtitles = _searchSubtitles;
 @synthesize forcePickSearchResult = _forcePickSearchResult;
 @synthesize shouldSortResults = _shouldSortResults;
+@synthesize shouldSearchInBackground = _shouldSearchInBackground;
 @synthesize tokenField = _tokenField;
 @synthesize resultsTable = _resultsTable;
 @synthesize contentView = _contentView;
@@ -71,6 +72,7 @@
     _searchSubtitles = YES;
     _forcePickSearchResult = NO;
   _shouldSortResults = YES;
+  _shouldSearchInBackground = NO;
 	_resultsArray = [NSMutableArray array];
 	
 	_tokenField = [[TITokenField alloc] initWithFrame:CGRectMake(0, 0, self.bounds.size.width, 42)];
@@ -322,38 +324,55 @@
 	searchString = [searchString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 	
 	if (searchString.length || _forcePickSearchResult){
-		[_sourceArray enumerateObjectsUsingBlock:^(id sourceObject, NSUInteger idx, BOOL *stop){
-			
-			NSString * query = [self searchResultStringForRepresentedObject:sourceObject];
-			NSString * querySubtitle = [self searchResultSubtitleForRepresentedObject:sourceObject];
-			if (!querySubtitle || !_searchSubtitles) querySubtitle = @"";
-			
-			if ([query rangeOfString:searchString options:NSCaseInsensitiveSearch].location != NSNotFound ||
-				[querySubtitle rangeOfString:searchString options:NSCaseInsensitiveSearch].location != NSNotFound ||
-                (_forcePickSearchResult && searchString.length == 0)){
-				
-				__block BOOL shouldAdd = ![_resultsArray containsObject:sourceObject];
-				if (shouldAdd && !_showAlreadyTokenized){
-					
-					[_tokenField.tokens enumerateObjectsUsingBlock:^(TIToken * token, NSUInteger idx, BOOL *secondStop){
-						if ([token.representedObject isEqual:sourceObject]){
-							shouldAdd = NO;
-							*secondStop = YES;
-						}
-					}];
-				}
-				
-				if (shouldAdd) [_resultsArray addObject:sourceObject];
-			}
-		}];
-	}
-    
-    if (_resultsArray.count > 0 && _shouldSortResults) {
-        [_resultsArray sortUsingComparator:^NSComparisonResult(id obj1, id obj2) {
-            return [[self searchResultStringForRepresentedObject:obj1] localizedCaseInsensitiveCompare:[self searchResultStringForRepresentedObject:obj2]];
-        }];
-        [_resultsTable reloadData];
+    if (_shouldSearchInBackground) {
+      [self performSelectorInBackground:@selector(performSearch:) withObject:searchString];
+    } else {
+      [self performSearch:searchString];
     }
+	}
+}
+
+- (void) performSearch:(NSString *)searchString {
+  NSMutableArray * resultsToAdd = [[NSMutableArray alloc] init];
+  [_sourceArray enumerateObjectsUsingBlock:^(id sourceObject, NSUInteger idx, BOOL *stop){
+
+    NSString * query = [self searchResultStringForRepresentedObject:sourceObject];
+    NSString * querySubtitle = [self searchResultSubtitleForRepresentedObject:sourceObject];
+    if (!querySubtitle || !_searchSubtitles) querySubtitle = @"";
+    
+    if ([query rangeOfString:searchString options:NSCaseInsensitiveSearch].location != NSNotFound ||
+				[querySubtitle rangeOfString:searchString options:NSCaseInsensitiveSearch].location != NSNotFound ||
+        (_forcePickSearchResult && searchString.length == 0)){
+
+      __block BOOL shouldAdd = ![resultsToAdd containsObject:sourceObject];
+      if (shouldAdd && !_showAlreadyTokenized){
+
+        [_tokenField.tokens enumerateObjectsUsingBlock:^(TIToken * token, NSUInteger idx, BOOL *secondStop){
+          if ([token.representedObject isEqual:sourceObject]){
+            shouldAdd = NO;
+            *secondStop = YES;
+          }
+        }];
+      }
+
+      if (shouldAdd) [resultsToAdd addObject:sourceObject];
+    }
+  }];
+
+  [_resultsArray addObjectsFromArray:resultsToAdd];
+  if (_resultsArray.count > 0) {
+    if (_shouldSortResults) {
+      [_resultsArray sortUsingComparator:^NSComparisonResult(id obj1, id obj2) {
+        return [[self searchResultStringForRepresentedObject:obj1] localizedCaseInsensitiveCompare:[self searchResultStringForRepresentedObject:obj2]];
+      }];
+    }
+    [self performSelectorOnMainThread:@selector(reloadResultsTable) withObject:nil waitUntilDone:YES];
+  }
+}
+
+-(void) reloadResultsTable {
+  [_resultsTable setHidden:NO];
+  [_resultsTable reloadData];
 }
 
 - (void)presentpopoverAtTokenFieldCaretAnimated:(BOOL)animated {

--- a/TokenFieldExample/Classes/TokenFieldExampleViewController.m
+++ b/TokenFieldExample/Classes/TokenFieldExampleViewController.m
@@ -33,6 +33,8 @@
 	[self.view addSubview:_tokenFieldView];
 	
 	[_tokenFieldView.tokenField setDelegate:self];
+	[_tokenFieldView setShouldSearchInBackground:NO];
+	[_tokenFieldView setShouldSortResults:NO];
 	[_tokenFieldView.tokenField addTarget:self action:@selector(tokenFieldFrameDidChange:) forControlEvents:TITokenFieldControlEventFrameDidChange];
 	[_tokenFieldView.tokenField setTokenizingCharacters:[NSCharacterSet characterSetWithCharactersInString:@",;."]]; // Default is a comma
     [_tokenFieldView.tokenField setPromptText:@"To:"];


### PR DESCRIPTION
When the list of source array is huge we want to perform a background search to prevent UI from getting laggy. This commit allows to do just that. It adds a configuration flag, turned off by default, which allows user to perform search in background thread.
