### PR TITLE
only add tokens of didBeginEditing if they were removed on didEndEditing

### DIFF
--- a/TITokenField.m
+++ b/TITokenField.m
@@ -538,7 +538,9 @@ NSString * const kTextHidden = @"\u200D"; // Zero-Width Joiner
 }
 
 - (void)didBeginEditing {
-	[_tokens enumerateObjectsUsingBlock:^(TIToken * token, NSUInteger idx, BOOL *stop){[self addToken:token];}];
+    if (_removesTokensOnEndEditing) {
+        	[_tokens enumerateObjectsUsingBlock:^(TIToken * token, NSUInteger idx, BOOL *stop){[self addToken:token];}];
+    }
 }
 
 - (void)didEndEditing {


### PR DESCRIPTION
seems like you should only be re-adding the tokens to the token field on didBeginEditing if _removesTokensOnEndEditing == YES? otherwise, you haven't removed them so there's no need to re-add them. also, in this scenario, there are unbalanced delegate callbacks. willAddToken: gets called even though willRemoveToken: was never called (since the tokens were never actually removed). this is bad if youre doing any sort of validation on willAddToken: to make sure you're not adding duplicate tokens.
