### PR TITLE
Custom search option to the delegate

### DIFF
--- a/TITokenField.h
+++ b/TITokenField.h
@@ -40,6 +40,9 @@
 - (BOOL)tokenField:(TITokenField *)tokenField willRemoveToken:(TIToken *)token;
 - (void)tokenField:(TITokenField *)tokenField didRemoveToken:(TIToken *)token;
 
+- (BOOL)tokenField:(TITokenField *)field shouldUseCustomSearchForSearchString:(NSString *)searchString;
+- (void)tokenField:(TITokenField *)field performCustomSearchForSearchString:(NSString *)searchString withCompletionHandler:(void (^)(NSArray *results))completionHandler;
+
 - (void)tokenField:(TITokenField *)tokenField didFinishSearch:(NSArray *)matches;
 - (NSString *)tokenField:(TITokenField *)tokenField displayStringForRepresentedObject:(id)object;
 - (NSString *)tokenField:(TITokenField *)tokenField searchResultStringForRepresentedObject:(id)object;


### PR DESCRIPTION
Add the option to delegate the search to the... delegate.

I used TITokenField in various app / projects (thanks for the library by the way), and a few times I needed to have either a custom search Algorithm or simply do an API call for the search.

There are various possibility to achieve that with the current TITokenField, but it is painful and add complexity.

I simply add 2 delegate methods

```
- (BOOL)tokenField:(TITokenField *)field shouldUseCustomSearchForSearchString:(NSString *)searchString;
- (void)tokenField:(TITokenField *)field performCustomSearchForSearchString:(NSString *)searchString withCompletionHandler:(void (^)(NSArray *results))completionHandler;
```

If your delegate implement `shouldUseCustomSearchForSearchString` and return `YES`
Then `performCustomSearchForSearchString` is called on your delegate. Your delegate is now responsible for performing the search, you can do whatever you want including an API call. All you need to do when you have your results ready is to call `completionHandler(results);` (ala background fetch ^^).

In the demo project I added a fun example, try searching for `contributors`.
