### PR TITLE
Fix: Half-Pixel blur due to non-integer values

### DIFF
--- a/TITokenField.m
+++ b/TITokenField.m
@@ -760,7 +760,7 @@ NSString * const kTextHidden = @"\u200D"; // Zero-Width Joiner
 	CGFloat leftMargin = self.leftViewWidth + 12;
 	CGFloat hPadding = 8;
 	CGFloat rightMargin = self.rightViewWidth + hPadding;
-	CGFloat lineHeight = self.font.lineHeight + topMargin + 5;
+	CGFloat lineHeight = ceilf(self.font.lineHeight) + topMargin + 5;
 	
 	_numberOfLines = 1;
 	_tokenCaret = (CGPoint){leftMargin, (topMargin - 1)};
@@ -789,7 +789,7 @@ NSString * const kTextHidden = @"\u200D"; // Zero-Width Joiner
 		}
 	}];
 	
-	return _tokenCaret.y + lineHeight;
+	return ceilf(_tokenCaret.y + lineHeight);
 }
 
 #pragma mark View Handlers


### PR DESCRIPTION
`font.lineHeight` returns non-integer value, which causes the second line of TIToken to be blur. This PR fixes this.
![screen shot 2014-01-31 at 4 19 42 pm](https://f.cloud.github.com/assets/955238/2056272/bd82c644-8ad6-11e3-8b44-42235794b550.png)
