### PR TITLE
token field state fix when tokenfield:didaddtoken: delegate method gets called

### DIFF
--- a/TITokenField.m
+++ b/TITokenField.m
@@ -705,7 +705,8 @@ NSString * const kTextHidden = @"\u200D"; // Zero-Width Joiner
 		
 		[token removeFromSuperview];
 		[_tokens removeObject:token];
-		
+        [self layoutTokensAnimated:YES];
+
 		if ([delegate respondsToSelector:@selector(tokenField:didRemoveToken:)]){
 			[delegate tokenField:self didRemoveToken:token];
 		}


### PR DESCRIPTION
when tokenField:didAddToken: gets fired, the state of the token field should reflect its state after the token has already been added. however, the frame of the token field has not yet changed to reflect the newly added token. this PR should fix this issue.
