### PR TITLE
Support auto layout by setting child frames when layoutSubviews happens, also added podspec file

### DIFF
--- a/TITokenField.m
+++ b/TITokenField.m
@@ -130,15 +130,19 @@
 }
 
 #pragma mark Property Overrides
+- (void) setChildFrames:(CGRect)frame {
+    CGFloat width = frame.size.width;
+    [_separator setFrame:((CGRect){_separator.frame.origin, {width, _separator.bounds.size.height}})];
+    [_resultsTable setFrame:((CGRect){_resultsTable.frame.origin, {width, _resultsTable.bounds.size.height}})];
+    [_contentView setFrame:((CGRect){_contentView.frame.origin, {width, (frame.size.height - CGRectGetMaxY(_tokenField.frame))}})];
+    [_tokenField setFrame:((CGRect){_tokenField.frame.origin, {width, _tokenField.bounds.size.height}})];
+}
+
 - (void)setFrame:(CGRect)frame {
 	
 	[super setFrame:frame];
 	
-	CGFloat width = frame.size.width;
-	[_separator setFrame:((CGRect){_separator.frame.origin, {width, _separator.bounds.size.height}})];
-	[_resultsTable setFrame:((CGRect){_resultsTable.frame.origin, {width, _resultsTable.bounds.size.height}})];
-	[_contentView setFrame:((CGRect){_contentView.frame.origin, {width, (frame.size.height - CGRectGetMaxY(_tokenField.frame))}})];
-	[_tokenField setFrame:((CGRect){_tokenField.frame.origin, {width, _tokenField.bounds.size.height}})];
+    [self setChildFrames:frame];
 	
 	if (_popoverController.popoverVisible){
 		[_popoverController dismissPopoverAnimated:NO];
@@ -169,6 +173,8 @@
 	
 	[super layoutSubviews];
 	
+    [self setChildFrames:self.frame];
+    
 	CGFloat relativeFieldHeight = CGRectGetMaxY(_tokenField.frame) - self.contentOffset.y;
 	CGFloat newHeight = self.bounds.size.height - relativeFieldHeight;
 	if (newHeight > -1) [_resultsTable setFrame:((CGRect){_resultsTable.frame.origin, {_resultsTable.bounds.size.width, newHeight}})];

--- a/TITokenField.podspec.json
+++ b/TITokenField.podspec.json
@@ -1,0 +1,22 @@
+{
+  "name": "TITokenField",
+  "version": "0.9.5.1",
+  "summary": "An iOS version of the NSTokenField (See To: field in Mail and Messages).",
+  "homepage": "https://github.com/Batterii/TITokenField",
+  "license": {
+    "type": "Dual-licensed (BSD and commercial)",
+    "text": "  This control is dual licensed: You can use it for free under the BSD licence below or, If you require non-attribution you can purchase the commercial licence available at http://www.cocoacontrols.com/authors/thermogl\n\nCopyright (c) 2012 Tom Irving. All rights reserved.\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:\n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.\n\nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.\n\nTHIS SOFTWARE IS PROVIDED BY TOM IRVING \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL TOM IRVING OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n"
+  },
+  "authors": {
+    "Tom Irving": "info@thermoglobalnuclearwar.com"
+  },
+  "source": {
+    "git": "https://github.com/thermogl/TITokenField.git",
+    "tag": "master"
+  },
+  "platforms": {
+    "ios": "5.0"
+  },
+  "source_files": "TITokenField.{h,m}",
+  "requires_arc": true
+}


### PR DESCRIPTION
I think this is required to make the field properly layout its subviews when it is inside of a view that is using auto-layout.  Without this I found that as auto-layout adjusted the TokeFieldView's frames it was not updating its child layout.

I also, added a podspec file.  Technically not related but without the podspec file in the repo it is a bit harder to work with in Cocoapods.