### PR TITLE
Fixed a couple issues/feature needs

### DIFF
--- a/TITokenField.h
+++ b/TITokenField.h
@@ -92,6 +92,7 @@ typedef enum {
 @property (weak, nonatomic, readonly) TIToken * selectedToken;
 @property (weak, nonatomic, readonly) NSArray * tokenTitles;
 @property (weak, nonatomic, readonly) NSArray * tokenObjects;
+@property (nonatomic, assign) BOOL showShadow;
 @property (nonatomic, assign) BOOL editable;
 @property (nonatomic, assign) BOOL resultsModeEnabled;
 @property (nonatomic, assign) BOOL removesTokensOnEndEditing;

--- a/TITokenField.m
+++ b/TITokenField.m
@@ -751,7 +751,7 @@ NSString * const kTextHidden = @"\u200D"; // Zero-Width Joiner
     [self addSubview:token];
     [self layoutTokensAnimated:YES];
     [self showOrHidePlaceHolderLabel];
-    [self setResultsModeEnabled:NO];
+    [self setResultsModeEnabled:_alwaysShowSearchResult];
     [self deselectSelectedToken];
 }
 

--- a/TITokenField.m
+++ b/TITokenField.m
@@ -477,6 +477,7 @@ NSString * const kTextHidden = @"\u200D"; // Zero-Width Joiner
 }
 @synthesize delegate = delegate;
 @synthesize editable = _editable;
+@synthesize showShadow = _showShadow;
 @synthesize resultsModeEnabled = _resultsModeEnabled;
 @synthesize removesTokensOnEndEditing = _removesTokensOnEndEditing;
 @synthesize numberOfLines = _numberOfLines;
@@ -516,18 +517,16 @@ NSString * const kTextHidden = @"\u200D"; // Zero-Width Joiner
 	[self addTarget:self action:@selector(didBeginEditing) forControlEvents:UIControlEventEditingDidBegin];
 	[self addTarget:self action:@selector(didEndEditing) forControlEvents:UIControlEventEditingDidEnd];
 	[self addTarget:self action:@selector(didChangeText) forControlEvents:UIControlEventEditingChanged];
-	
-	[self.layer setShadowColor:[[UIColor blackColor] CGColor]];
-	[self.layer setShadowOpacity:0.6];
-	[self.layer setShadowRadius:12];
-	
+
 	[self setPromptText:@"To:"];
     	[self setText:kTextEmpty];
 	
 	_internalDelegate = [[TITokenFieldInternalDelegate alloc] init];
 	[_internalDelegate setTokenField:self];
 	[super setDelegate:_internalDelegate];
-	
+
+    [self setShowShadow:YES];
+    
 	_tokens = [NSMutableArray array];
 	_editable = YES;
 	_removesTokensOnEndEditing = YES;
@@ -538,8 +537,19 @@ NSString * const kTextHidden = @"\u200D"; // Zero-Width Joiner
 #pragma mark Property Overrides
 - (void)setFrame:(CGRect)frame {
 	[super setFrame:frame];
-	[self.layer setShadowPath:[[UIBezierPath bezierPathWithRect:self.bounds] CGPath]];
+    [self.layer setShadowPath:[[UIBezierPath bezierPathWithRect:self.bounds] CGPath]];
 	[self layoutTokensAnimated:NO];
+}
+
+- (void)setShowShadow:(BOOL)showShadow {
+    _showShadow = showShadow;
+    if (showShadow) {
+        [self.layer setShadowColor:[[UIColor blackColor] CGColor]];
+        [self.layer setShadowOpacity:0.6];
+        [self.layer setShadowRadius:12];
+    } else {
+        [self.layer setShadowColor:[[UIColor clearColor] CGColor]];
+    }
 }
 
 - (void)setText:(NSString *)text {

--- a/TITokenField.m
+++ b/TITokenField.m
@@ -839,7 +839,7 @@ NSString * const kTextHidden = @"\u200D"; // Zero-Width Joiner
 	if (self.bounds.size.height != newHeight){
 		
 		// Animating this seems to invoke the triple-tap-delete-key-loop-problem-thing™
-		[UIView animateWithDuration:(animated ? 0.3 : 0) animations:^{
+		[UIView animateWithDuration:(animated && _editable ? 0.3 : 0) animations:^{
 			[self setFrame:((CGRect){self.frame.origin, {self.bounds.size.width, newHeight}})];
 			[self sendActionsForControlEvents:(UIControlEvents)TITokenFieldControlEventFrameWillChange];
 			

--- a/TITokenField.podspec.json
+++ b/TITokenField.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "TITokenField",
-  "version": "0.9.5.1",
+  "version": "0.9.5.2",
   "summary": "An iOS version of the NSTokenField (See To: field in Mail and Messages).",
   "homepage": "https://github.com/Batterii/TITokenField",
   "license": {


### PR DESCRIPTION
Sorry this is one pull request.  Was just seeing if these changes might be useful to others...

1. The "always show results" mode was causing the results table to hide as soon as text was being typed and then show again instead of just staying up.
2. Turned off animation for token layout if in non-edit mode since this seemed like a pretty distracting behavior if just showing the list of tokens in a table view cell or read only field
3. Added an option to turn off the token shadows